### PR TITLE
change to configure pypi index

### DIFF
--- a/auth-demo/pyproject.toml
+++ b/auth-demo/pyproject.toml
@@ -14,3 +14,7 @@ dependencies = [
     "pyarrow>=20.0.0",
     "pyjwt>=2.10.1",
 ]
+
+[[tool.uv.index]]
+url = "https://pypi-proxy.dev.databricks.com/simple"
+default = true


### PR DESCRIPTION
This fix is needed to solve this error:

```
uv run python app.py
  × Failed to download and build `thrift==0.20.0`
  ├─▶ Failed to resolve requirements from `setup.py` build
  ├─▶ No solution found when resolving: `setuptools>=40.8.0`
  ├─▶ Request failed after 3 retries
  ├─▶ Failed to fetch: `https://pypi.org/simple/setuptools/`
  ├─▶ error sending request for url (https://pypi.org/simple/setuptools/)
  ├─▶ client error (Connect)
  ╰─▶ tls handshake eof
  help: `thrift` (v0.20.0) was included because `auth-demo` (v0.1.0) depends on `databricks-sql-connector` (v4.0.3) which
        depends on `thrift`
```